### PR TITLE
Fix #5942 - ENOENT on `npm exec`

### DIFF
--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -186,7 +186,7 @@ const exec = async (opts) => {
 
     args[0] = getBinFromManifest(commandManifest)
 
-    if (needInstall.length > 0 && globalPath) {
+    if (needInstall.length > 0 && await fileExists(globalPath)) {
       // See if the package is installed globally, and run the translated bin
       const globalArb = new Arborist({ ...flatOptions, path: globalPath, global: true })
       const globalTree = await globalArb.loadActual()


### PR DESCRIPTION
When running `npm exec` and the global path specified using config's `prefix` doesn't exist, execution fails when npm lfirst ooks for the package availability at global level to run it. Testing the presence of the `prefix` (a.k.a `globalPath`) directory rather than just testing the `globalPath` directive fix this issue.

This bug was introduced by commit 19a834610d154f36748536b27aed13bfdb5ee748, so this patch can be backported to npm > 8.12.1